### PR TITLE
QRZ(): remove code for disabling SSL verification

### DIFF
--- a/qrz/qrz_query.py
+++ b/qrz/qrz_query.py
@@ -41,7 +41,6 @@ class QRZ(object):
 
         url = '''https://xmldata.qrz.com/xml/current/?username={0}&password={1}'''.format(username, password)
         self._session = requests.Session()
-        self._session.verify = bool(os.getenv('SSL_VERIFY', False))
         r = self._session.get(url)
         if r.status_code == 200:
             raw_session = xmltodict.parse(r.content)


### PR DESCRIPTION
Rationale:

In HTTPS access for qrz.com, the host should always be verified by the TLS/SSL certificate.

Implementation details:

* Python `requests` package uses `urllib3`
* In many cases using `urllib3` include importing `certifi`
* By importing certifi, you're ready to verify the TLS/SSL certificate

See <https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification> for the further details.